### PR TITLE
fix: make main() return int

### DIFF
--- a/CMtoMT.cpp
+++ b/CMtoMT.cpp
@@ -3,7 +3,7 @@ using namespace std;
 
 
 
-void main()
+int main()
 {
 int cm;
 float mt;


### PR DESCRIPTION
fix the error 
```CMtoMT.cpp:6:1: error: ‘::main’ must return ‘int’```